### PR TITLE
Update scraper to the new table structure

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -32,10 +32,8 @@ def scrape_list(url)
       tds.insert(3, nil) if tds.count == 5 # combined constituency
 
       link = URI.join url, tds[1].css('a/@href').text
-      date_field = i == 0 ? 'start_date' : 'end_date'
       area_id, area = tds[2].text.split(/\s*\/\s*/, 2).map(&:tidy)
-
-      data = { 
+      data = {
         id: link.to_s[/idm=(\d+)/, 1],
         name: tds[1].text.tidy,
         faction: tds[4].text.tidy,
@@ -44,8 +42,9 @@ def scrape_list(url)
         term: 2012,
         source: link.to_s,
       }.merge(scrape_person(link))
-      data[date_field] = date_parse(tds[5].text)
-      # puts data[:name]
+      data[:start_date] = date_parse(tds[5].text)
+      data[:end_date]   = date_parse(tds[6].text) if tds.count == 7
+
       ScraperWiki.save_sqlite([:id, :term], data)
     end
   end
@@ -54,7 +53,7 @@ end
 def scrape_person(url)
   noko = noko_for(url)
   box = noko.css('.stiri-detalii')
-  data = { 
+  data = {
     sort_name: box.xpath('.//h1/text()').first.text.tidy,
     image: box.css('.profile-pic-dep img/@src').text,
     birth_date: date_parse(box.css('.profile-pic-dep').text.tidy),


### PR DESCRIPTION
We were missing `end_dates` because the structure of the scraped table changed (added one extra column and we were still scraping the one that now contains start dates instead)

I checked that we recovered the dates with `SELECT start_date FROM data;` and `SELECT end_date FROM data;`
